### PR TITLE
middleware builder interface

### DIFF
--- a/.changeset/fuzzy-wombats-itch.md
+++ b/.changeset/fuzzy-wombats-itch.md
@@ -1,0 +1,5 @@
+---
+"@next-safe/middleware": minor
+---
+
+provide a uniform middleware builder and configuration interface. Add some more configuration options to `strictDynamic.`

--- a/.changeset/old-forks-poke.md
+++ b/.changeset/old-forks-poke.md
@@ -1,0 +1,5 @@
+---
+"e2e": patch
+---
+
+update `_middleware` with configuration capabilites from new builder interface 

--- a/.changeset/swift-chefs-beam.md
+++ b/.changeset/swift-chefs-beam.md
@@ -1,0 +1,5 @@
+---
+"e2e": patch
+---
+
+add types and detection for reporting data payloads. Use them in `/api/reporting` endpoint.

--- a/apps/e2e/pages/_middleware.ts
+++ b/apps/e2e/pages/_middleware.ts
@@ -2,42 +2,40 @@ import {
   chain,
   nextSafe,
   strictDynamic,
-  reporting
+  reporting,
 } from "@next-safe/middleware";
 
 const isDev = process.env.NODE_ENV === "development";
+const reportOnly = !!process.env.CSP_REPORT_ONLY;
 
-const nextSafeMiddleware = nextSafe((req, res) => {
+const nextSafeMiddleware = nextSafe((req) => {
   return {
     isDev,
     contentSecurityPolicy: {
+      reportOnly,
       "style-src": `'unsafe-inline'`,
+      "connect-src": `'self' ${req.nextUrl.origin}`,
     },
     // customize as you need: https://trezy.gitbook.io/next-safe/usage/configuration
   };
 });
 
-const vercelUrl = process.env.VERCEL_URL
-const reportEndpoint = vercelUrl ? `https://${vercelUrl}/api/reporting` : ""
-
-const reportingMiddleware = reporting({
-  csp: {
-    reportUri: process.env.CSP_REPORT_URI || reportEndpoint || "https://example.com/csp-report-uri",
-    reportSample: true
-  },
-  reportTo: {
-    max_age: 1800,
-    endpoints: [
-      {
-        url: process.env.CSP_REPORT_TO || reportEndpoint || "https://example.com/reporting-api",
-      },
-    ],
-  },
-
+const reportingMiddleware = reporting((req) => {
+  const nextApiReportEndpoint = `${req.nextUrl.origin}/api/reporting`;
+  return {
+    csp: {
+      reportUri: process.env.CSP_REPORT_URI || nextApiReportEndpoint,
+      reportSample: true,
+    },
+    reportTo: {
+      max_age: 1800,
+      endpoints: [
+        {
+          url: process.env.REPORT_TO_ENDPOINT_DEFAULT || nextApiReportEndpoint,
+        },
+      ],
+    },
+  };
 });
 
-export default chain(
-  nextSafeMiddleware,
-  strictDynamic(),
-  reportingMiddleware
-);
+export default chain(nextSafeMiddleware, strictDynamic(), reportingMiddleware);

--- a/apps/e2e/pages/api/reporting.ts
+++ b/apps/e2e/pages/api/reporting.ts
@@ -1,7 +1,16 @@
-import type { NextApiHandler } from 'next';
+import type { NextApiHandler } from "next";
+import { extractReportingData } from "types/reporting";
 
 const handler: NextApiHandler = (req, res) => {
-    console.log('Reporting API data', { body: req.body, method: req.method })
-    res.status(200).json({ message: 'logged reporting data'})
-}
+  const reportingData = extractReportingData(req.body);
+  if (reportingData) {
+    console.log(JSON.stringify(reportingData));
+    // Accepted: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+    res.status(202).end();
+    return;
+  }
+  // Unprocessable Entity: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+  res.status(422).end();
+};
+
 export default handler;

--- a/apps/e2e/types/reporting.ts
+++ b/apps/e2e/types/reporting.ts
@@ -1,0 +1,93 @@
+// type info based from log extraction with https://transform.tools/json-to-typescript
+
+export type ReportToItemBase = {
+  age: number;
+  url: string;
+  user_agent: string;
+};
+
+export type ReportToBodyCspViolation = {
+  blockedURL: string;
+  disposition: string;
+  documentURL: string;
+  effectiveDirective: string;
+  lineNumber: number;
+  originalPolicy: string;
+  referrer: string;
+  sample: string;
+  sourceFile: string;
+  statusCode: number;
+};
+
+export type ReportToCspViolationItem = ReportToItemBase & {
+  type: "csp-violation";
+  body: ReportToBodyCspViolation;
+};
+
+// can be extended with cased types to paint the whole report-to picture
+export type ReportToItem = ReportToCspViolationItem;
+export type ReportToPayload = ReportToItem[];
+
+export type CspReport = {
+  "blocked-uri": string;
+  "column-number": number;
+  "document-uri": string;
+  "line-number": number;
+  "original-policy": string;
+  referrer: string;
+  "script-sample": string;
+  "source-file": string;
+  "violated-directive": string;
+};
+
+export type CspReportUriPayload = {
+  "csp-report": CspReport;
+};
+
+export type ReportToData = {
+  kind: "report-to";
+  data: ReportToPayload;
+};
+export type CspReportUriData = {
+  kind: "csp-report";
+  data: CspReport;
+};
+
+export type ReportingData = ReportToData | CspReportUriData;
+
+// TODO: find out what's required and what's optional
+export const isReportToItem = (x: any): x is ReportToItem => {
+  const requiredKeys = ["age", "type", "body"];
+  return (
+    typeof x === "object" &&
+    Object.keys(x).filter((key) => key in requiredKeys).length ===
+      requiredKeys.length
+  );
+};
+
+export const isReportToPayload = (x: any): x is ReportToPayload => {
+  return Array.isArray(x) && x.every(isReportToItem);
+};
+
+export const isCspReportUriPayload = (x: any): x is CspReportUriPayload => {
+  return typeof x === "object" && !!x["csp-report"];
+};
+
+export const extractReportingData = (
+  data: unknown
+): ReportingData | undefined => {
+  if (isReportToPayload(data)) {
+    return {
+      kind: "report-to",
+      data,
+    };
+  }
+  if (isCspReportUriPayload(data)) {
+    const kind = "csp-report";
+    return {
+      kind,
+      data: data[kind],
+    };
+  }
+  return undefined;
+};

--- a/packages/next-safe-middleware/src/middleware/builder.ts
+++ b/packages/next-safe-middleware/src/middleware/builder.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { mergeDeepRight } from "ramda";
+import {
+  EnsuredMiddleware,
+  Middleware,
+  MiddlewareBuilder,
+  MiddlewareConfig,
+} from "./types";
+
+export const unpackConfig = async <Config extends Record<string, unknown>>(
+  req: NextRequest,
+  res: Response,
+  cfg: MiddlewareConfig<Config>
+) => {
+  return typeof cfg === "function" ? cfg(req, res) : cfg;
+};
+
+export const mergeConfigs =
+  <Config extends Record<string, unknown>>(
+    left: MiddlewareConfig<Config>,
+    right: MiddlewareConfig<Config>
+  ) =>
+  async (req: NextRequest, res: Response) => {
+    const leftCfg = await unpackConfig(req, res, left);
+    const rightCfg = await unpackConfig(req, res, right);
+    return mergeDeepRight(leftCfg, rightCfg) as Config;
+  };
+
+export const withDefaultConfig =
+  <Config extends Record<string, unknown>>(
+    builder: MiddlewareBuilder<Config>,
+    defaultCfg: MiddlewareConfig<Config>
+  ) =>
+  (cfg?: MiddlewareConfig<Config>) => {
+    if (cfg) {
+      return builder(mergeConfigs(defaultCfg, cfg));
+    } else {
+      return builder(defaultCfg);
+    }
+  };
+
+export const ensureChainContext = (
+  middleware: EnsuredMiddleware,
+  ensureResponse: (
+    req: NextRequest
+  ) => Response | Promise<Response> = NextResponse.next
+): Middleware => {
+  return async (req, evt, res, next) => {
+    const ensuredRes = res || (await ensureResponse(req));
+    const ensuredNext = next || (() => void 0);
+    ensuredNext(ensuredRes);
+    return middleware(req, evt, ensuredRes, ensuredNext);
+  };
+};

--- a/packages/next-safe-middleware/src/middleware/chain.ts
+++ b/packages/next-safe-middleware/src/middleware/chain.ts
@@ -1,5 +1,5 @@
-import type { NextFetchEvent, NextRequest } from 'next/server';
-import type { Middleware } from './types';
+import type { NextFetchEvent, NextRequest } from "next/server";
+import type { Middleware } from "./types";
 
 // https://www.youtube.com/watch?v=tVCUAXOBF7w
 const weAreChained =

--- a/packages/next-safe-middleware/src/middleware/index.ts
+++ b/packages/next-safe-middleware/src/middleware/index.ts
@@ -1,13 +1,19 @@
-export * from './types';
-export * from './utils';
-export { default as chain } from './chain';
-export { default as nextSafe } from './nextSafe';
-export * from './nextSafe';
-export { default as reporting } from './reporting';
-export * from './reporting';
-import strictDynamic from './strictDynamic';
-export { strictDynamic }
+export * from "./types";
+export * from "./utils";
+
+export { default as chain } from "./chain";
+
+export { default as nextSafe } from "./nextSafe";
+export type { NextSafeCfg } from "./nextSafe";
+
+export { default as reporting } from "./reporting";
+export type { ReportingCfg } from "./reporting";
+
+import { default as strictDynamic } from "./strictDynamic";
+export { strictDynamic };
+export type { StrictDynamicCfg } from "./strictDynamic";
+
 /**
  * @deprecated use the `strictDynamic` middleware builder to configure a strict CSP.
  */
-export const provideHashesOrNonce = strictDynamic()
+export const provideHashesOrNonce = strictDynamic();

--- a/packages/next-safe-middleware/src/middleware/types.ts
+++ b/packages/next-safe-middleware/src/middleware/types.ts
@@ -1,8 +1,33 @@
-import type { NextFetchEvent, NextRequest } from 'next/server';
+import type { NextFetchEvent, NextRequest, NextResponse } from "next/server";
+
+type NextMiddlewareResult = NextResponse | Response | null | undefined | void;
+
+type NextMiddleware = (
+  request: NextRequest,
+  event: NextFetchEvent
+) => NextMiddlewareResult | Promise<NextMiddlewareResult>;
 
 export type Middleware = (
+  ...params: [
+    ...spec: Parameters<NextMiddleware>,
+    res?: Response,
+    next?: (res: Response) => void
+  ]
+) => ReturnType<NextMiddleware>;
+
+export type EnsuredMiddleware = (
+  ...params: Required<Parameters<Middleware>>
+) => ReturnType<Middleware>;
+
+export type ConfigInitalizer<Config extends Record<string, unknown>> = (
   req: NextRequest,
-  evt: NextFetchEvent,
-  res?: Response,
-  next?: (res: Response) => void
-) => Promise<Response | void> | Response | void;
+  res: Response
+) => Config | Promise<Config>;
+
+export type MiddlewareConfig<Config extends Record<string, unknown>> =
+  | Config
+  | ConfigInitalizer<Config>;
+
+export type MiddlewareBuilder<Config extends Record<string, unknown>> = (
+  cfg: MiddlewareConfig<Config>
+) => Middleware;

--- a/packages/next-safe-middleware/src/middleware/utils.ts
+++ b/packages/next-safe-middleware/src/middleware/utils.ts
@@ -1,43 +1,54 @@
 import type { CSP } from "../types";
-import { CSP_HEADER, CSP_HEADER_REPORT_ONLY, CSP_NONCE_HEADER } from "../constants";
+import {
+  CSP_HEADER,
+  CSP_HEADER_REPORT_ONLY,
+  CSP_NONCE_HEADER,
+} from "../constants";
 import { fromCspContent, toCspContent } from "../utils";
 import { nanoid } from "nanoid";
 
-export const setCspHeader = (cspContent: string, res: Response, reportOnly?: boolean) => {
+export const setCspHeader = (
+  cspContent: string,
+  res: Response,
+  reportOnly?: boolean
+) => {
   const isReportOnly = reportOnly ?? !!res.headers.get(CSP_HEADER_REPORT_ONLY);
-  if(isReportOnly) {
-    res.headers.delete(CSP_HEADER)
-    res.headers.set(CSP_HEADER_REPORT_ONLY, cspContent)
+  if (isReportOnly) {
+    res.headers.delete(CSP_HEADER);
+    res.headers.set(CSP_HEADER_REPORT_ONLY, cspContent);
+  } else {
+    res.headers.delete(CSP_HEADER_REPORT_ONLY);
+    res.headers.set(CSP_HEADER, cspContent);
   }
-  else {
-    res.headers.delete(CSP_HEADER_REPORT_ONLY)
-    res.headers.set(CSP_HEADER, cspContent)
-  }
-}
+};
 
 export const getCspHeader = (res: Response) => {
-  return res.headers.get(CSP_HEADER) || res.headers.get(CSP_HEADER_REPORT_ONLY)
-}
+  return res.headers.get(CSP_HEADER) || res.headers.get(CSP_HEADER_REPORT_ONLY);
+};
 
 export const pullCspFromResponse: (res: Response) => CSP | undefined = (
   res
 ) => {
-  const cspContent = getCspHeader(res)
+  const cspContent = getCspHeader(res);
   if (cspContent) {
     return fromCspContent(cspContent);
   }
   return undefined;
 };
 
-export const pushCspToResponse = (csp: CSP, res: Response, reportOnly?: boolean) => {
-  setCspHeader(toCspContent(csp), res, reportOnly)
+export const pushCspToResponse = (
+  csp: CSP,
+  res: Response,
+  reportOnly?: boolean
+) => {
+  setCspHeader(toCspContent(csp), res, reportOnly);
 };
 
 export const cspNonce = (res: Response) => {
-  let nonce = res.headers.get(CSP_NONCE_HEADER)
-  if(!nonce) {
-    nonce = nanoid()
-    res.headers.set(CSP_NONCE_HEADER, nonce)
+  let nonce = res.headers.get(CSP_NONCE_HEADER);
+  if (!nonce) {
+    nonce = nanoid();
+    res.headers.set(CSP_NONCE_HEADER, nonce);
   }
-  return nonce
-}
+  return nonce;
+};


### PR DESCRIPTION
make the configuration more streamlined and flexible and implementation more predictable.

all configuration params are the configuration object itself or an (async) initializer for the configuration object, that can read request data and read/write response data (in chain) . 

it's easy to give any middleware builder a sane default config (will be deep merged with the passed config)
