### PR TITLE
hotfix for broken ISR mode

### DIFF
--- a/.changeset/gentle-tomatoes-study.md
+++ b/.changeset/gentle-tomatoes-study.md
@@ -1,0 +1,5 @@
+---
+"@next-safe/middleware": patch
+---
+
+use correct call order in `render()` of custom `Document` components. That should prevent things from breaking in ISR mode.

--- a/.changeset/stupid-beds-perform.md
+++ b/.changeset/stupid-beds-perform.md
@@ -1,0 +1,5 @@
+---
+"@next-safe/middleware": patch
+---
+
+fetch script/style hashes for `/404` route if a request has no route/page. This makes strict CSP work with a custom `pages/404.js`.

--- a/.changeset/thick-papayas-sleep.md
+++ b/.changeset/thick-papayas-sleep.md
@@ -1,0 +1,5 @@
+---
+"e2e": patch
+---
+
+add a custom css-in-js styled `pages/404.tsx`

--- a/apps/e2e/pages/404.tsx
+++ b/apps/e2e/pages/404.tsx
@@ -1,0 +1,14 @@
+import tw, { styled } from "twin.macro";
+import Container from "components/Container";
+
+const Error = styled("pre", {
+  ...tw`font-mono text-red-600 text-2xl sm:text-5xl xl:text-7xl `,
+});
+
+export default () => (
+  <div tw="min-h-screen flex flex-col justify-center">
+    <Container isCentered>
+      <Error>404 - Page not found</Error>
+    </Container>
+  </div>
+);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "clean": "yarn workspaces foreach -p run clean",
     "dev": "yarn build && yarn workspaces foreach -pvi run dev",
-    "dev::no-cache": "yarn build --ignore-cache && yarn workspaces foreach -pvi run dev",
+    "dev:no-cache": "yarn build --ignore-cache && yarn workspaces foreach -pvi run dev",
     "start": "yarn build && yarn workspace e2e start",
     "start:no-cache": "yarn build --ignore-cache && yarn workspace e2e start",
     "test": "yarn workspaces foreach -pv run test",

--- a/packages/next-safe-middleware/package.json
+++ b/packages/next-safe-middleware/package.json
@@ -11,7 +11,7 @@
     "node": ">=10"
   },
   "yarn.build": {
-    "input": "src",
+    "input": ["src", "rollup.config.js"],
     "output": "dist"
   },
   "scripts": {

--- a/packages/next-safe-middleware/src/document/utils.tsx
+++ b/packages/next-safe-middleware/src/document/utils.tsx
@@ -28,10 +28,13 @@ const isKnownScriptAttr = (attr: string) =>
   ].includes(attr);
 
 export const isJsxElement = (el: any): el is JSX.Element =>
-  typeof el === "object" && !!el["type"] && el["props"]
+  typeof el === "object" && "props" in el
+
+export const isElementWithChildren = (el: any): el is JSX.Element =>
+  isJsxElement(el) && "children" in el.props
 
 export const isScriptElement = (el: any): el is JSX.Element =>
-  isJsxElement(el)  && el.type === "script";
+  isJsxElement(el) && el.type === "script";
 
 export const isStyleElement = (el: unknown): el is JSX.Element =>
   isJsxElement(el) && el.type === "style";
@@ -85,7 +88,10 @@ export const createTrustedLoadingProxy = (els: JSX.Element[]) => {
     "proxy-self-7f10ba7a15bc0318e7dd56e8c7e1cff"
   );
   const id = integritySha256(proxy).replace(/^sha256-/g, "");
-  const inlineCode = proxy.replace(/proxy-self-7f10ba7a15bc0318e7dd56e8c7e1cff/g, id);
+  const inlineCode = proxy.replace(
+    /proxy-self-7f10ba7a15bc0318e7dd56e8c7e1cff/g,
+    id
+  );
   const async = iterableScripts.every((s) => !!getScriptValue("async", s));
   const defer = iterableScripts.every((s) => !!getScriptValue("defer", s));
   return (

--- a/packages/next-safe-middleware/src/middleware/strictDynamic.ts
+++ b/packages/next-safe-middleware/src/middleware/strictDynamic.ts
@@ -98,7 +98,7 @@ export type StrictDynamicCfg = {
  */
 const strictDynamic: MiddlewareBuilder<StrictDynamicCfg> = (cfg) =>
   ensureChainContext(async (req, evt, res) => {
-    if (process.env.NODE_ENV === "development" || !req.page.name) {
+    if (process.env.NODE_ENV === "development") {
       return;
     }
     const csp = pullCspFromResponse(res) ?? {};

--- a/packages/next-safe-middleware/src/middleware/strictInlineStyles.ts
+++ b/packages/next-safe-middleware/src/middleware/strictInlineStyles.ts
@@ -21,7 +21,7 @@ export type StrictInlineStylesCfg = {
 
 const strictInlineStyles: MiddlewareBuilder<StrictInlineStylesCfg> = (cfg) =>
   ensureChainContext(async (req, evt, res) => {
-    if (process.env.NODE_ENV === "development" || !req.page.name) {
+    if (process.env.NODE_ENV === "development") {
       return;
     }
     const { extendStyleSrc } = await unpackConfig(req, res, cfg);


### PR DESCRIPTION

Observed a strange error on the ISR page only happening sometimes (non-deterministic errors, the best).. I am not always able to reproduce them and that they happen in the browser is also a hint that it doesn't have something to do with Document, as that always only happens on the server.

So unsure whether this is a bug specific to this package or a general problem of Next 12.1 ISR, I just observed it the first time randomly after releasing `0.5.0`, but could well haven been present in earliert versions as well.

<details>
<summary>browser console dump</summary>

```
lazy-slug:1 Hello from _document/Head, I get nonced/hashed there
lazy-slug:16 Hi I am inline-script running with strategy beforeInteractive
lazy-slug:29 Refused to apply inline style because it violates the following Content Security Policy directive: "style-src 'sha256-1OmTvgZnV2y503pdDjohQS0RuBBsauWBUJYHpkseH6g=' 'sha256-0h0Ha1KEXibxI1pkH1Ag1lqpMsbVx7SR13/64S1f0iI=' 'report-sample'". Either the 'unsafe-inline' keyword, a hash ('sha256-Cqk5P+rWS46CfnewVXPxAE3iEvjAkwf8NKx38Yy0XEE='), or a nonce ('nonce-...') is required to enable inline execution.

lazy-slug:29 Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'strict-dynamic' https: 'unsafe-inline' 'sha256-2AH2VH1B+5jBCXgwJkVuj1TRGO0aUm9dcNatWrnyosU=' 'sha256-/YBoshFg0h4c8uChMOdoW9bj/DioQZjlW4VJlX63+4E=' 'sha384-WkFzsrcXKeJ3KlWNXojDiim8rplIj1RPsCbuv7dsLECoXY8C6Cx158CMgl+O+QKW' 'sha256-HbfGq/YyS2lEO5UGlrEV3HHZLeNfos3dEw1SNKznMtg=' 'sha256-Mh/Mym75xv4TF9QQB93xKzs1mDikrfTAeZb0VysQ1PE=' 'sha256-kNrz7joEYYu85XK9pK1f5jlGPkdk+b7sMQv6hOkDLxE=' 'sha256-KbYdymQrHNf4ALji8f84zlbNQyFvVcCfDnzBCkhvBpA=' 'sha256-hHUVori7BmahjJTmJo5kYMo5++zOGu5qT9zmAvf7+Rw=' 'sha256-D8VYFsUD6Lne6ojWrRDDxAYcDWjRC9m0IOGIotp6iQM=' 'sha256-k+txFJHVC0lSVMCWUYQJs3bVdBKXUrer8DKYHWvAnc4=' 'sha256-YLtjRCa3LCiwvrVSIXibTbw/h+pjHRaZ2uyTHcnHkJ0=' 'sha256-Venu3/ZAgbpZgzEBMChPmB68B5VSt+MhkeuBpL0oYGQ=' 'sha256-fLWoemwNBaqyJFy/aiatrYDNMiVA1fY2Dd5iG/kidD8=' 'sha256-YBBkeKg8ZMrOVcagwW82+MWAyr/dTbyqXxjR/kVDbG0=' 'sha256-npRF6Yavi9cmuBycyi8hjGx/E+X9Q3D7I/a92VjtB+E=' 'sha256-IkG3Zhvh1SYmCfHPlQwLYtojcIhRaYYkjdbMpAT/r6E=' 'report-sample'". Note that 'unsafe-inline' is ignored if either a hash or nonce value is present in the source list.

_app-02a9023ac288257f.js:1 Refused to apply inline style because it violates the following Content Security Policy directive: "style-src 'sha256-1OmTvgZnV2y503pdDjohQS0RuBBsauWBUJYHpkseH6g=' 'sha256-0h0Ha1KEXibxI1pkH1Ag1lqpMsbVx7SR13/64S1f0iI=' 'report-sample'". Either the 'unsafe-inline' keyword, a hash ('sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='), or a nonce ('nonce-...') is required to enable inline execution.

c @ _app-02a9023ac288257f.js:1
main-d4132ff526603c93.js:formatted:479 TypeError: Cannot read properties of null (reading 'cssRules')
    at c (_app-02a9023ac288257f.js:1:17836)
    at I (_app-02a9023ac288257f.js:1:17988)
    at _app-02a9023ac288257f.js:1:23398
    at _app-02a9023ac288257f.js:1:9856
    at _app-02a9023ac288257f.js:1:23039
    at da (_app-02a9023ac288257f.js:1:23654)
    at Object.8061 (_app-02a9023ac288257f.js:1:24126)
    at i (webpack-78d6b4957d2000fb.js:1:145)
    at Object.147 (_app-02a9023ac288257f.js:1:170)
    at i (webpack-78d6b4957d2000fb.js:1:145)
oa @ main-d4132ff526603c93.js:formatted:479
main-d4132ff526603c93.js:formatted:480 A client-side exception has occurred, see here for more info: https://nextjs.org/docs/messages/client-side-exception-occurred
oa @ main-d4132ff526603c93.js:formatted:480
_app-02a9023ac288257f.js:1 Refused to apply inline style because it violates the following Content Security Policy directive: "style-src 'sha256-1OmTvgZnV2y503pdDjohQS0RuBBsauWBUJYHpkseH6g=' 'sha256-0h0Ha1KEXibxI1pkH1Ag1lqpMsbVx7SR13/64S1f0iI=' 'report-sample'". Either the 'unsafe-inline' keyword, a hash ('sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='), or a nonce ('nonce-...') is required to enable inline execution.

c @ _app-02a9023ac288257f.js:1
vue.js:9279 You are running a development build of Vue.
Make sure to use the production build (*.prod.js) when deploying for production.
framework-0ea1eedc195949f2.js:1 Error: Minified React error #130; visit https://reactjs.org/docs/error-decoder.html?invariant=130&args[]=undefined&args[]= for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
    at Pi (framework-0ea1eedc195949f2.js:1:107300)
    at l (framework-0ea1eedc195949f2.js:1:52854)
    at framework-0ea1eedc195949f2.js:1:55207
    at framework-0ea1eedc195949f2.js:1:55475
    at Kg (framework-0ea1eedc195949f2.js:1:67219)
    at i (framework-0ea1eedc195949f2.js:1:114612)
    at yi (framework-0ea1eedc195949f2.js:1:98708)
    at wi (framework-0ea1eedc195949f2.js:1:98636)
    at vi (framework-0ea1eedc195949f2.js:1:98499)
    at ni (framework-0ea1eedc195949f2.js:1:95467)
fh @ framework-0ea1eedc195949f2.js:1
main-d4132ff526603c93.js:formatted:479 Error: Minified React error #130; visit https://reactjs.org/docs/error-decoder.html?invariant=130&args[]=undefined&args[]= for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
    at Pi (framework-0ea1eedc195949f2.js:1:107300)
    at l (framework-0ea1eedc195949f2.js:1:52854)
    at framework-0ea1eedc195949f2.js:1:55207
    at framework-0ea1eedc195949f2.js:1:55475
    at Kg (framework-0ea1eedc195949f2.js:1:67219)
    at i (framework-0ea1eedc195949f2.js:1:114612)
    at yi (framework-0ea1eedc195949f2.js:1:98708)
    at wi (framework-0ea1eedc195949f2.js:1:98636)
    at vi (framework-0ea1eedc195949f2.js:1:98499)
    at ni (framework-0ea1eedc195949f2.js:1:95467)
oa @ main-d4132ff526603c93.js:formatted:479
main-d4132ff526603c93.js:formatted:480 A client-side exception has occurred, see here for more info: https://nextjs.org/docs/messages/client-side-exception-occurred
oa @ main-d4132ff526603c93.js:formatted:480
main-d4132ff526603c93.js:formatted:554 Error rendering page:  TypeError: Cannot read properties of undefined (reading 'getInitialProps')
    at main-d4132ff526603c93.js:formatted:3405:31
    at j (main-d4132ff526603c93.js:formatted:3927:32)
    at Generator._invoke (main-d4132ff526603c93.js:formatted:4022:33)
    at Generator.a.<computed> [as next] (main-d4132ff526603c93.js:formatted:3956:37)
    at b (main-d4132ff526603c93.js:formatted:3574:29)
    at h (main-d4132ff526603c93.js:formatted:3589:25)
    at main-d4132ff526603c93.js:formatted:3594:21
    at new Promise (<anonymous>)
    at Object.<anonymous> (main-d4132ff526603c93.js:formatted:3586:24)
    at Object.q (main-d4132ff526603c93.js:formatted:3446:18)
(anonymous) @ main-d4132ff526603c93.js:formatted:554
DevTools failed to load source map: Could not load content for chrome-extension://ihkokciokaeljncgdpafbgafdpbocdab/rdt_tailwind.umd.min.js.map: HTTP error: status code 404, net::ERR_UNKNOWN_URL_SCHEME
```

</details>

<details>
<summary>failed location in main bundle (formatted)</summary>

![2022-03-06 07_36_20](https://user-images.githubusercontent.com/52962482/156912184-edc6bc33-c269-4ea0-8add-54a77559136b.png)


</details>