### PR TITLE
add hash of empty string to style hashes

### DIFF
--- a/.changeset/nervous-starfishes-carry.md
+++ b/.changeset/nervous-starfishes-carry.md
@@ -1,0 +1,5 @@
+---
+"@next-safe/middleware": patch
+---
+
+add hash of empty string to style hashes. CSS-in-js frameworks like stitches seem to need it to not break during hydration

--- a/packages/next-safe-middleware/src/document/HashingHead.tsx
+++ b/packages/next-safe-middleware/src/document/HashingHead.tsx
@@ -250,6 +250,8 @@ export class Head extends NextHead {
   render() {
     trustifyChildren(this.props.children);
     const styleHashes = [
+      // hashing empty avoid breaking things with ISR (tested with stitches).
+      integritySha256(""),
       ...collectStyleHashes(this.context.styles),
       ...collectStyleHashes(this.props.children),
     ];

--- a/packages/next-safe-middleware/src/document/HashingHead.tsx
+++ b/packages/next-safe-middleware/src/document/HashingHead.tsx
@@ -253,9 +253,7 @@ export class Head extends NextHead {
       ...collectStyleHashes(this.context.styles),
       ...collectStyleHashes(this.props.children),
     ];
-    const rendered = super.render();
-    styleHashes.push(...collectStyleHashes(rendered));
     writeStyleHashesToJson(this.context, styleHashes);
-    return rendered;
+    return super.render();
   }
 }

--- a/packages/next-safe-middleware/src/document/NoncingHead.tsx
+++ b/packages/next-safe-middleware/src/document/NoncingHead.tsx
@@ -39,8 +39,6 @@ export class Head extends NextHead {
     const nonce = this.props.nonce;
     noncifyChildren(nonce, this.context.styles);
     noncifyChildren(nonce, this.props.children);
-    const rendered = super.render();
-    noncifyChildren(nonce, rendered);
-    return rendered;
+    return super.render();
   }
 }


### PR DESCRIPTION
CSS-in-js frameworks like stitches seem to need it to not break during hydration