### PR TITLE
fix: use open-ended peerDependency ranges

### DIFF
--- a/.changeset/young-years-pump.md
+++ b/.changeset/young-years-pump.md
@@ -1,0 +1,5 @@
+---
+"@next-safe/middleware": patch
+---
+
+fix: use open-ended peerDependency ranges

--- a/packages/next-safe-middleware/package.json
+++ b/packages/next-safe-middleware/package.json
@@ -24,8 +24,8 @@
     "test": "jest --runInBand"
   },
   "peerDependencies": {
-    "next": "^12",
-    "react": "^17"
+    "next": ">=12",
+    "react": ">=17"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^21.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1014,8 +1014,8 @@ __metadata:
     typescript: ^4.5.5
     ua-parser-js: ^1.0.2
   peerDependencies:
-    next: ^12
-    react: ^17
+    next: ">=12"
+    react: ">=17"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Right now the install with npm is failing along React 18. If I force install I can't recognise any issue at all.