### PR TITLE
Fix require-trusted-types-for

### DIFF
--- a/.changeset/yellow-apricots-tan.md
+++ b/.changeset/yellow-apricots-tan.md
@@ -1,0 +1,5 @@
+---
+"@strict-csp/builder": patch
+---
+
+Make require-trusted-types-for produce a valid header

--- a/packages/builder/src/builder.spec.ts
+++ b/packages/builder/src/builder.spec.ts
@@ -99,4 +99,10 @@ describe("CSP Builder", () => {
     const expectBuilder = new CspBuilder().withStrictDynamic(hashes);
     expect(expectBuilder.csp()).toEqual(fixtureBuilder.csp());
   });
+
+  it("can quotes script in require-trusted-types-for correctly", () => {
+    const fixtureBuilder = new CspBuilder(`require-trusted-types-for 'script';`);
+    const expectBuilder = new CspBuilder().withDirectives({"require-trusted-types-for": ["script"]});
+    expect(expectBuilder.toString()).toEqual(fixtureBuilder.toString());
+  });
 });

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -41,7 +41,7 @@ export class CspBuilder {
         const isCspHeader = param[0] === CSP_HEADER;
         const isCspReportOnlyHeader = param[0] === CSP_HEADER_REPORT_ONLY;
         if (!(isCspHeader || isCspReportOnlyHeader)) {
-          this._csp = empty;
+          this._csp = {...empty};
         } else {
           this._csp = {
             directives: fromCspContent(param[1]),
@@ -58,7 +58,7 @@ export class CspBuilder {
         };
       }
     } else {
-      this._csp = empty;
+      this._csp = {...empty};
     }
   }
 
@@ -212,7 +212,7 @@ export class CspBuilder {
   }
 
   public reset() {
-    this._csp = empty;
+    this._csp = {...empty};
   }
 
   public isEmpty() {

--- a/packages/builder/src/utils.ts
+++ b/packages/builder/src/utils.ts
@@ -19,6 +19,7 @@ const singleQuotify = (directiveValue: string) => `'${directiveValue}'`;
 
 const isLiteralDirectiveValue = (directiveValue: string) => {
   const c1 = [
+    "script",
     "strict-dynamic",
     "report-sample",
     "self",


### PR DESCRIPTION
This is a fix for #75 

I added "script" to the set of literal directive values and added a test for it.

I couldn't get the tests to run without using `--runInBand` which runs all the tests in a single thread which exposed that `empty` was getting reused across tests. So I changed the uses of empty to create a new object rather than use the one shared constant.