### PR TITLE
Fix ssr redirect/notFound results

### DIFF
--- a/packages/next-safe-middleware/src/document/NextPageContext/index.ts
+++ b/packages/next-safe-middleware/src/document/NextPageContext/index.ts
@@ -14,7 +14,7 @@ export function gsspWithNonce<
     if ("props" in gsspResult) {
       const nonce = getCreateCtxNonceIdempotent(ctx);
       const props = await gsspResult.props;
-      return { props: { ...props, nonce } };
+      return { ...gsspResult, props: { ...props, nonce } };
     }
   };
 }


### PR DESCRIPTION
https://nextjs.org/docs/api-reference/data-fetching/get-server-side-props#notfound

Our app makes use of the ssr result object notFound and redirect keys.
I've just spread those back into the result of the getServerSideProps wrapping gsspWithNonce function.
